### PR TITLE
Add typecheck to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 cache: yarn
 
 before_script:
+  - yarn typecheck
   - yarn lint
 
 after_script:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev": "webpack-dev-server --inline --hot --mode development",
     "build": "webpack --mode production",
     "clean": "rimraf dist/ coverage/",
+    "typecheck": "tsc --noEmit",
     "lint": "tslint --project .",
     "test": "jest --coverage",
     "coverage": "codecov -f coverage/*.json"


### PR DESCRIPTION
Use TypeScript `tsc --noEmit` to check for type errors in CI