### PR TITLE
Use landlord's "Extra Estate" PowerUp

### DIFF
--- a/src/actions/powerupsActions.ts
+++ b/src/actions/powerupsActions.ts
@@ -1,0 +1,32 @@
+import { Dispatch } from "react-redux";
+import { Action, EmptyAction } from ".";
+import { api } from "../api/client";
+import { PowerUp } from "../state/store";
+
+export enum PowerUpActions {
+  StartFetching = "start_fetching_purchased_powerups",
+  FinishFetching = "finish_fetching_purchased_powerups",
+}
+
+const startFetchingPurchasedPowerUps = () : EmptyAction => ({
+  type: PowerUpActions.StartFetching,
+});
+
+const finishFetchingPurchasedPowerUps = (powerups: PowerUp[]) : Action<PowerUp[]> => ({
+  type: PowerUpActions.FinishFetching,
+  value: powerups,
+});
+
+export const fetchPurchasedPowerUps = () => {
+  return async (dispatch: Dispatch) => {
+    dispatch(startFetchingPurchasedPowerUps());
+
+    try {
+      const powerups = await api.fetchUserPowerups();
+
+      dispatch(finishFetchingPurchasedPowerUps(powerups));
+    } catch {
+      dispatch(finishFetchingPurchasedPowerUps([]));
+    }
+  };
+};

--- a/src/actions/storeActions.ts
+++ b/src/actions/storeActions.ts
@@ -2,6 +2,7 @@ import { Dispatch } from "react-redux";
 import { Action, EmptyAction } from ".";
 import { api } from "../api/client";
 import { PowerUp, Purchase } from "../state/store";
+import { fetchPurchasedPowerUps } from "./powerupsActions";
 
 export enum StoreActions {
   StartFetching = "start_fetching_powerups",
@@ -59,6 +60,7 @@ export const purchasePowerUp = (id: string, quantity: number) => {
 
     try {
       await api.purchasePowerUp(purchase);
+      await fetchPurchasedPowerUps()(dispatch);
 
       success = true;
     } finally {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -71,11 +71,15 @@ export class ApiClient extends HttpClient {
   }
 
   public async fetchPowerUps() : Promise<PowerUp[]> {
-    return await this.get<PowerUp[]>(`${this.baseUrl}/powerups`);
+    return await this.get<PowerUp[]>(`${this.baseUrl}/powerups/store`);
   }
 
   public async purchasePowerUp(purchase: Purchase) : Promise<PowerUp[]> {
-    return await this.post<PowerUp[]>(`${this.baseUrl}/powerups`, purchase);
+    return await this.post<PowerUp[]>(`${this.baseUrl}/powerups/store`, purchase);
+  }
+
+  public async fetchUserPowerups() : Promise<PowerUp[]> {
+    return await this.get<PowerUp[]>(`${this.baseUrl}/powerups`);
   }
 
   public async usePowerUp(id: string) : Promise<PowerUp[]> {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router";
 import { bindActionCreators, Dispatch } from "redux";
 import { fetchBiography } from "../actions/biographyActions";
+import { fetchPurchasedPowerUps } from "../actions/powerupsActions";
 import { AccommoDateState, Fetchable } from "../state";
 import { Dashboard } from "./Dashboard";
 import { Landing } from "./landing/Landing";
@@ -10,12 +11,14 @@ import { Landing } from "./landing/Landing";
 interface AppProps extends RouteComponentProps<any> {
   login: Fetchable<boolean>;
   fetchBiography: typeof fetchBiography;
+  fetchPurchasedPowerUps: typeof fetchPurchasedPowerUps;
 }
 
 export class AppComponent extends React.PureComponent<AppProps> {
   public componentWillMount() {
     if (this.props.login.value) {
       this.props.fetchBiography();
+      this.props.fetchPurchasedPowerUps();
     }
   }
 
@@ -39,6 +42,7 @@ const mapStateToProps = (state: AccommoDateState) => ({
 const mapDispatchToProps = (dispatch: Dispatch) => {
   return bindActionCreators({
     fetchBiography,
+    fetchPurchasedPowerUps,
   }, dispatch);
 };
 

--- a/src/components/profile/EditLandlordProfile.tsx
+++ b/src/components/profile/EditLandlordProfile.tsx
@@ -4,8 +4,9 @@ import { connect, Dispatch } from "react-redux";
 import { bindActionCreators } from "redux";
 import { addRealEstate, updateBiography } from "../../actions/biographyActions";
 import { startEditing } from "../../actions/editorActions";
-import { AccommoDateState } from "../../state";
+import { AccommoDateState, Fetchable } from "../../state";
 import { LandlordBiography, RealEstate } from "../../state/biography";
+import { PowerUp } from "../../state/store";
 import { EditableChoice } from "../cards/EditableChoice";
 import { EditablePreferenceCollection } from "../cards/EditablePreferenceCollection";
 import { EditableText } from "../cards/EditableText";
@@ -15,6 +16,7 @@ import { SavedMessage } from "./SavedMessage";
 
 interface EditLandlordProfileProps {
   biography: LandlordBiography;
+  powerups: Fetchable<PowerUp[]>;
 
   saved: boolean;
   saving: boolean;
@@ -132,12 +134,21 @@ class EditLandlordProfileComponent extends React.PureComponent<EditLandlordProfi
   }
 
   private renderAddRealEstateButton() {
+    let canAddRealEstate = false;
+
+    if (this.props.powerups.value) {
+      const extraEstatePowerUps = this.props.powerups.value.filter((powerup) => powerup.name === "Extra Estate");
+
+      canAddRealEstate = (extraEstatePowerUps.length + 1) > this.props.biography.realEstates.length;
+    }
+
     return (
       <Button
         icon="plus"
         type="primary"
         loading={this.props.saving}
         onClick={this.props.addRealEstate}
+        disabled={!canAddRealEstate}
       >
         New
       </Button>
@@ -146,6 +157,7 @@ class EditLandlordProfileComponent extends React.PureComponent<EditLandlordProfi
 }
 
 const mapStateToProps = (state: AccommoDateState) => ({
+  powerups: state.powerups,
   saved: state.editor.value,
   saving: !!state.editor.isFetching,
 });

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -3,6 +3,7 @@ import { biographyReducer } from "./biographyReducer";
 import { editorReducer } from "./editorReducer";
 import { loginReducer } from "./loginReducer";
 import { matchingReducer } from "./matchingReducer";
+import { powerupsReducer } from "./powerupsReducer";
 import { signupReducer } from "./signupReducer";
 import { storeReducer } from "./storeReducer";
 
@@ -11,6 +12,7 @@ export const rootReducer = combineReducers({
   editor: editorReducer,
   login: loginReducer,
   matchingState: matchingReducer,
+  powerups: powerupsReducer,
   signup: signupReducer,
   store: storeReducer,
 });

--- a/src/reducers/powerupsReducer.ts
+++ b/src/reducers/powerupsReducer.ts
@@ -1,0 +1,24 @@
+import { Action, EmptyAction } from "../actions";
+import { PowerUpActions } from "../actions/powerupsActions";
+import { defaultFetchableState, Fetchable } from "../state";
+import { PowerUp } from "../state/store";
+
+export const powerupsReducer = (state: Fetchable<PowerUp[]> = defaultFetchableState, action: EmptyAction & Action<PowerUp[]>) : Fetchable<PowerUp[]> => {
+  switch (action.type) {
+    case PowerUpActions.StartFetching:
+      return {
+        ...state,
+        isFetching: true,
+      };
+
+    case PowerUpActions.FinishFetching:
+      return {
+        ...state,
+        isFetching: false,
+        value: action.value,
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -5,7 +5,7 @@ import {
   defaultMatchingState,
   MatchingState,
 } from "./match";
-import { defaultPowerUpStoreState, PowerUpStore } from "./store";
+import { defaultPowerUpStoreState, PowerUp, PowerUpStore } from "./store";
 
 export interface Fetchable<T = any> {
   isFetching: boolean;
@@ -24,6 +24,7 @@ export interface AccommoDateState {
   biography: Fetchable<Biography>;
   editor: Editor;
   matchingState: MatchingState;
+  powerups: Fetchable<PowerUp[]>;
 }
 
 export const defaultState: AccommoDateState = {
@@ -34,6 +35,7 @@ export const defaultState: AccommoDateState = {
     value: api.isLoggedIn || false,
   },
   matchingState: defaultMatchingState,
+  powerups: defaultFetchableState,
   signup: defaultFetchableState,
   store: defaultPowerUpStoreState,
 };

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -15,9 +15,11 @@ describe("AppComponent", () => {
   };
 
   let fetchBiography;
+  let fetchPurchasedPowerups;
 
   beforeEach(() => {
     fetchBiography = spy();
+    fetchPurchasedPowerups = spy();
   });
 
   it("displays the landing page if the user is not logged in", () => {
@@ -26,7 +28,14 @@ describe("AppComponent", () => {
       value: false,
     };
 
-    const rendered = shallow(<AppComponent {...routeProps} login={login} fetchBiography={fetchBiography} />);
+    const rendered = shallow(
+      <AppComponent
+        {...routeProps}
+        login={login}
+        fetchBiography={fetchBiography}
+        fetchPurchasedPowerUps={fetchPurchasedPowerups}
+      />,
+    );
 
     expect(rendered.contains(<Landing />)).toBeTruthy();
   });
@@ -37,18 +46,34 @@ describe("AppComponent", () => {
       value: true,
     };
 
-    const rendered = shallow(<AppComponent {...routeProps} login={login} fetchBiography={fetchBiography} />);
+    const rendered = shallow(
+      <AppComponent
+        {...routeProps}
+        login={login}
+        fetchBiography={fetchBiography}
+        fetchPurchasedPowerUps={fetchPurchasedPowerups}
+      />,
+    );
 
     expect(rendered.contains(<Dashboard />)).toBeTruthy();
   });
 
-  it("fetches the biography on startup", () => {
+  it("fetches biography and powerups on startup", () => {
     const login: Fetchable<boolean> = {
       ...defaultFetchableState,
       value: true,
     };
 
-    shallow(<AppComponent {...routeProps} login={login} fetchBiography={fetchBiography} />);
+    shallow(
+      <AppComponent
+        {...routeProps}
+        login={login}
+        fetchBiography={fetchBiography}
+        fetchPurchasedPowerUps={fetchPurchasedPowerups}
+      />,
+    );
+
     expect(fetchBiography.calledOnce).toBeTruthy();
+    expect(fetchPurchasedPowerups.calledOnce).toBeTruthy();
   });
 });


### PR DESCRIPTION
As a proof of concept, this prevents landlords from adding more real estates if they didn't purchase the "Extra Estate" PowerUp.